### PR TITLE
Accept multiple simple paths when accessing attributes.

### DIFF
--- a/spec/acceptance/basic_behavior_spec.rb
+++ b/spec/acceptance/basic_behavior_spec.rb
@@ -15,7 +15,7 @@ describe 'basic behavior with a simple JSON document' do
   class User
     include LazyDoc::DSL
 
-    access :name
+    access :name, :phone
     access :address, via: :streetAddress
     access :job_title, via: [:profile, :occupation, :title]
     access :born_on, via: [:profile, :bornOn], finally: lambda { |born_on| born_on.to_i }
@@ -32,6 +32,7 @@ describe 'basic behavior with a simple JSON document' do
   subject(:user) { User.new(json_file) }
 
   its(:name) { should == 'Tyler Durden' }
+  its(:phone) { should == '288-555-0153' }
   its(:address) { should == 'Paper Street' }
   its(:job_title) { should == 'Soap Maker' }
   its(:born_on) { should == 1999 }

--- a/spec/acceptance/support/user.json
+++ b/spec/acceptance/support/user.json
@@ -1,5 +1,6 @@
 {
   "name": "Tyler Durden",
+  "phone": "288-555-0153",
   "streetAddress": "Paper Street",
   "profile": {
     "bornOn": "1999",

--- a/spec/lib/lazy_doc/dsl_spec.rb
+++ b/spec/lib/lazy_doc/dsl_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../spec_helper'
 module LazyDoc
   describe DSL do
     describe '.access' do
-      let(:json) { '{"foo":"bar"}' }
+      let(:json) { '{"foo":"bar", "blarg":"wibble"}' }
 
       subject(:test_find) { Object.new }
 
@@ -36,6 +36,18 @@ module LazyDoc
 
         expect(test_find.foo).to eq("bar")
       end
+
+      it 'provides simple access to more than one attribute' do
+        test_find.singleton_class.access :foo, :blarg
+        test_find.lazily_embed(json)
+
+        expect(test_find.foo).to eq("bar")
+        expect(test_find.blarg).to eq("wibble")
+      end
+
+      it 'raises ArgumentError when more than one attribute is accessed with options' do
+        expect { test_find.singleton_class.access :foo, :blarg, as: Foo}.to raise_error(ArgumentError, "Options provided for more than one attribute.")
+      end	
 
       context 'via' do
         it 'defines a method that accesses a named json attribute' do


### PR DESCRIPTION
I thought about refactoring #access a couple of different ways, but I think this is a straightforward implementation, and I'm interested in getting your feedback.  I assumed from your TODO that 'multiple simple paths' implies no options for this usage.
